### PR TITLE
Implemented HTCP client for Varnish purge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+restbase
+coverage
+config.yaml
+node_modules
+npm-debug.log
+# WebStorm IDE files
+.idea/*

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,3 @@
+coverage
+node_modules
+test

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,37 @@
+{
+	"predef": [
+		"ve",
+
+		"setImmediate",
+
+		"QUnit",
+
+		"Map",
+		"Set"
+	],
+
+	"bitwise": true,
+	"laxbreak": true,
+	"curly": true,
+	"eqeqeq": true,
+	"immed": true,
+	"latedef": "nofunc",
+	"newcap": true,
+	"noarg": true,
+	"noempty": true,
+	"nonew": true,
+	"regexp": false,
+	"undef": true,
+	"strict": true,
+	"trailing": true,
+
+	"smarttabs": true,
+	"multistr": true,
+
+	"node": true,
+
+	"nomen": false,
+	"loopfunc": true,
+        "esnext": true
+	//"onevar": true
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+    - "0.10"
+    - "0.12"
+    - "iojs"
+
+before_script:
+  - sleep 5
+
+notifications:
+  email:
+    - services@wikimedia.org
+
+script: npm run-script coverage && (npm run-script coveralls || exit 0)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,116 @@
+"use strict";
+
+require('core-js/shim');
+
+var P = require('bluebird');
+var dgram = P.promisifyAll(require('dgram'));
+var jsPack = require('jspack').jspack;
+
+/**
+ * Creates a new cache purger instance
+ *
+ * @param options object containing options for a cache purger:
+ *  - log:    logging function (default no-op)
+ *  - routes: array of route objects to map a resource url to the cache endpoint
+ *      - rule: ether regex for a resource url, or 'undefined' if it's a default endpoint
+ *      - host: cache endpoint host
+ *      - port: cache endpount port
+ *  - multicast_ttl: standard UDP multicast TTL option (default 8)
+ * @constructor
+ */
+function HTCPPurger(options) {
+    var self = this;
+    self.options = options || {};
+    self.log = self.options.log || function() {};
+
+    if (!self.options.routes) {
+       throw new Error('Config error. At least one route must be specified');
+    }
+
+    self.options.routes.forEach(function(routeSpec) {
+        if (routeSpec.rule && /^\/.+\/$/.test(routeSpec.rule)) {
+            var regExp = new RegExp(routeSpec.rule.substring(1, routeSpec.rule.length - 1));
+            routeSpec.rule = function(url) {
+                return regExp.test(url);
+            };
+        } else {
+            routeSpec.rule = function() { return true; };
+        }
+    });
+
+    self.options.multicast_ttl = self.options.multicast_ttl || 8;
+
+    self.seqReqId = 1;
+}
+
+/**
+ * Construct a UDP datagram with HTCP packet for Varnish flush of the url
+ * @param url a url of the resource that should be flushed
+ * @returns {Buffer} resulting HTCP packet bytes
+ * @private
+ */
+HTCPPurger.prototype._constructHTCPRequest = function(url) {
+    var self = this;
+    var htcpSpecifier = jsPack.Pack('!H4sH' + url.length + 'sH8sH',
+        [4, 'HEAD', url.length, url, 8, 'HTTP/1.0', 0]);
+    var htcpDataLen = 8 + 2 + htcpSpecifier.length;
+    var htcpLen = 4 + htcpDataLen + 2;
+    var result = jsPack.Pack('!HxxHBxLxx' + htcpSpecifier.length + 'AH',
+        [htcpLen, htcpDataLen, 4, self.seqReqId++, htcpSpecifier, 2]);
+    return new Buffer(result);
+};
+
+/**
+ * Lookup a cache endpoint for a concrete URL, based on options
+ * supplied in constructor
+ * @param url URL to lookup cache endpoint for
+ * @returns {Object} an opbject with host and port keys
+ * @private
+ */
+HTCPPurger.prototype._lookupRoute = function(url) {
+    var self = this;
+    var route = self.options.routes.find(function(route) {
+        return route.rule(url);
+    });
+    if (!route) {
+        self.log('error/htcp-purge', {
+            msg: 'Could not find route for ' + url
+        });
+        return undefined;
+    }
+    return {
+        host: route.host,
+        port: route.port
+    };
+};
+
+/**
+ * Purge a list of resources cahced under provided URLs
+ *
+ * @param urls array of urls to purge
+ */
+HTCPPurger.prototype.purge = function(urls) {
+    var self = this;
+    var socket = dgram.createSocket('udp4');
+    return socket.bindAsync()
+    .then(function() {
+        socket.setMulticastLoopback(false);
+        socket.setMulticastTTL(self.options.multicast_ttl);
+    })
+    .then(function() {
+        return P.all(urls.map(function(url) {
+            var datagram = self._constructHTCPRequest(url);
+            var route = self._lookupRoute(url);
+            if (route) {
+                return socket.sendAsync(datagram, 0, datagram.length, route.port, route.host);
+            } else {
+                return P.resolve();
+            }
+        }));
+    })
+    .then(function() {
+        socket.close();
+    });
+};
+
+module.exports = HTCPPurger;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "htcp-purge",
+  "version": "0.1.0",
+  "description": "Varnish caches purging method",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha",
+    "coverage": "istanbul cover _mocha -- -R spec",
+    "coveralls": "cat ./coverage/lcov.info | coveralls"
+  },
+  "keywords": [
+    "varnish",
+    "cache",
+    "mediawiki"
+  ],
+  "author": "",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "core-js": "^0.9.18",
+    "jspack": "^0.0.4",
+    "bluebird": "2.8.2"
+  },
+  "devDependencies": {
+    "istanbul": "^0.3.15",
+    "mocha": "^2.2.5",
+    "mocha-jshint": "^2.2.3",
+    "mocha-lcov-reporter": "^0.0.2"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,12 +8,16 @@
     "coverage": "istanbul cover _mocha -- -R spec",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/wikimedia/htcp-purge.git"
+  },
   "keywords": [
     "varnish",
     "cache",
     "mediawiki"
   ],
-  "author": "",
+  "author": "Wikimedia Service Team <services@wikimedia.org>",
   "license": "Apache-2.0",
   "dependencies": {
     "core-js": "^0.9.18",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "core-js": "^0.9.18",
-    "jspack": "^0.0.4",
     "bluebird": "2.8.2"
   },
   "devDependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,105 @@
+"use strict";
+
+require('mocha-jshint')();
+
+var HTCPPurger = require('../index');
+var assert = require('assert');
+var dgram = require('dgram');
+
+describe('Protocol tests', function() {
+    var referenceBuffer = new Buffer([0, 44, 0, 0, 0, 38, 4, 0,
+        0, 0, 0, 1, 0, 0, 0, 4, 72, 69, 65, 68, 0, 8,
+        116, 101, 115, 116, 46, 99, 111, 109, 0, 8, 72,
+        84, 84, 80, 47, 49, 46, 48, 0, 0, 0, 2]);
+    var referenceBuffer2 = new Buffer([0, 44, 0, 0, 0, 38, 4, 0,
+        0, 0, 0, 2, 0, 0, 0, 4, 72, 69, 65, 68, 0, 8,
+        116, 101, 115, 116, 46, 99, 111, 109, 0, 8, 72,
+        84, 84, 80, 47, 49, 46, 48, 0, 0, 0, 2]);
+
+    it('should construct correct datagram', function() {
+        var purger = new HTCPPurger({
+            routes: [
+                {
+                    host: 'default',
+                    port: 4827
+                }
+            ]
+        });
+        var resultDatagram = purger._constructHTCPRequest('test.com');
+        assert.deepEqual(referenceBuffer, resultDatagram);
+    });
+
+    it ('should lookup route by regex', function() {
+        var purger = new HTCPPurger({
+            routes: [
+                {
+                    rule: '/https?:\\/\\/test\\.com/',
+                    host: '123.123.123.123',
+                    port: 1234
+                },
+                {
+                    host: 'default',
+                    port: 1234
+                }
+            ]
+        });
+        var route = purger._lookupRoute('http://test.com');
+        assert.deepEqual('123.123.123.123', route.host);
+        assert.deepEqual(1234, route.port);
+        var route2 = purger._lookupRoute('http://test2.com');
+        assert.deepEqual('default', route2.host);
+        assert.deepEqual(1234, route2.port);
+    });
+
+    it ('should send datagrams' ,function(done) {
+        var purger = new HTCPPurger({
+            routes: [
+                {
+                    host: 'localhost',
+                    port: 12345
+                }
+            ]
+        });
+        var server = dgram.createSocket('udp4');
+        server.on("message", function (msg) {
+            assert.deepEqual(referenceBuffer, msg);
+            done();
+        });
+        server.bind(12345);
+        return purger.purge(['test.com'])
+        .then(function() {
+            server.close();
+        });
+    });
+
+    it ('should increase seq num of datagrams' ,function(done) {
+        var purger = new HTCPPurger({
+            routes: [
+                {
+                    host: 'localhost',
+                    port: 12345
+                }
+            ]
+        });
+        var server = dgram.createSocket('udp4');
+        var msgIdx = 1;
+        server.on("message", function (msg) {
+            if (msgIdx === 1) {
+                assert.deepEqual(referenceBuffer, msg);
+                msgIdx++;
+            } else {
+                assert.deepEqual(referenceBuffer2, msg);
+                done();
+            }
+        });
+        server.bind(12345);
+
+        return purger.purge(['test.com'])
+        .delay(100)
+        .then(function() {
+            return purger.purge(['test.com']);
+        })
+        .delay(100)
+        .then(function() { server.close(); })
+    });
+});


### PR DESCRIPTION
This is a direct translation of [PHP code](https://github.com/wikimedia/mediawiki/blob/b79196778ed7c4f49ae09bee9ba16f861a6e3760/includes/deferred/SquidUpdate.php#L140-L233) to node.js

Interesting part is a replacement of a PHP pack function, which uses [jspack](https://www.npmjs.com/package/jspack) lib. This one appears to be the best replacement, because it has same capabilities and API. There are native modules available for that, which are basically compiled from the C code of a PHP engine and claim to work faster, but here speed is not that big a problem (updates would be done async), but native dependency is, as we try to avoid them, and it doesn't even compile on my local machine.

Another issues is testing: varnishes are not available in vagrant, and prod varnishes are not available from localhost. So, all testing that I've done is feeding different urls to php and node modules and looking at the datagram contents - they match.

To resolve this issue we'd need to set up this lib with RESTBase, but lets do it after we settle on this PR.

Bug: https://phabricator.wikimedia.org/T109742
