### PR TITLE
Old node

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,33 +57,33 @@ HTCPPurger.prototype._constructHTCPRequest = function(url) {
 
     var result = new Buffer(htcpLen);
     // Length
-    result.writeIntBE(htcpLen, 0, 2);
+    result.writeInt16BE(htcpLen, 0);
     // Major-minor version
-    result.writeIntBE(0, 2, 2);
+    result.writeInt16BE(0, 2);
     // Data length
-    result.writeIntBE(htcpDataLen, 4, 2);
+    result.writeInt16BE(htcpDataLen, 4);
     // Op code & response
-    result.writeIntBE(4, 6, 1);
+    result.writeInt8(4, 6);
     // Reserved & flags
-    result.writeIntBE(0, 7, 1);
+    result.writeInt8(0, 7);
     // Transaction Id - seq number of a a request
-    result.writeIntBE(self.seqReqId++, 8, 4);
+    result.writeInt32BE(self.seqReqId++, 8);
 
     // HTCP packet contents - CLR specifier
     // Reserved & reason
-    result.writeIntBE(0, 12, 2);
+    result.writeInt16BE(0, 12);
     // COUNTSTR method: length + method (HEAD & GET are equivalent)
-    result.writeIntBE(4, 14, 2);
+    result.writeInt16BE(4, 14);
     result.write('HEAD', 16, 4);
     // COUNTSTR uri: length + URI
-    result.writeIntBE(urlByteLen, 20, 2);
+    result.writeInt16BE(urlByteLen, 20);
     result.write(url, 22, urlByteLen);
     // COUNTSTR version: length + http version
-    result.writeIntBE(8, 22 + urlByteLen, 2);
+    result.writeInt16BE(8, 22 + urlByteLen);
     result.write('HTTP/1.0', 24 + urlByteLen, 8);
     // COUNTSTR headers: empty, use just as padding
-    result.writeIntBE(0, 32 + urlByteLen, 2);
-    result.writeIntBE(2, 14 + htcpSpecifierLen, 2);
+    result.writeInt16BE(0, 32 + urlByteLen);
+    result.writeInt16BE(2, 14 + htcpSpecifierLen);
 
     return result;
 };

--- a/package.json
+++ b/package.json
@@ -8,12 +8,16 @@
     "coverage": "istanbul cover _mocha -- -R spec",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/wikimedia/htcp-purge.git"
+  },
   "keywords": [
     "varnish",
     "cache",
     "mediawiki"
   ],
-  "author": "",
+  "author": "Wikimedia Service Team <services@wikimedia.org>",
   "license": "Apache-2.0",
   "dependencies": {
     "core-js": "^0.9.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htcp-purge",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Varnish caches purging method",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -52,6 +52,7 @@ describe('Protocol tests', function() {
     });
 
     it ('should send datagrams' ,function(done) {
+        this.timeout(5000);
         var purger = new HTCPPurger({
             routes: [
                 {
@@ -67,6 +68,7 @@ describe('Protocol tests', function() {
         });
         server.bind(12345);
         return purger.purge(['test.com'])
+        .delay(100)
         .then(function() {
             server.close();
         });
@@ -77,7 +79,7 @@ describe('Protocol tests', function() {
             routes: [
                 {
                     host: 'localhost',
-                    port: 12345
+                    port: 12346
                 }
             ]
         });
@@ -92,7 +94,7 @@ describe('Protocol tests', function() {
                 done();
             }
         });
-        server.bind(12345);
+        server.bind(12346);
 
         return purger.purge(['test.com'])
         .delay(100)


### PR DESCRIPTION
I've completely neglected compatibility with node 0.10 in the previous version, where node `Buffer` doesn't have a general `writeIntBE` method.
