### PR TITLE
ES6, ESLint, exclusive option, new API

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,1 @@
+extends: 'eslint-config-node-services'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-    - "0.10"
-    - "0.12"
-    - "iojs"
+    - "4"
+    - "6"
 
 before_script:
   - sleep 5

--- a/maintenance/purge.js
+++ b/maintenance/purge.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var HTCPPurger = require('../index.js');
+const HTCPPurger = require('../index.js');
 
 function validateArgs() {
     if (process.argv.length !== 4) {
         return false;
     }
-    var varnishIP = process.argv[2];
+    const varnishIP = process.argv[2];
     return /(?:\d{1,3}\.){3}\d{1,3}:\d{4}/.test(varnishIP);
 
 }
@@ -15,13 +15,13 @@ if (!validateArgs()) {
     process.exit(1);
 }
 
-var varnishIP = process.argv[2];
-var purgeURL = process.argv[3];
-var hostPortMatch = varnishIP.match(/((?:\d{1,3}\.){3}\d{1,3}):(\d{4})/);
-var varnishHostIp = hostPortMatch[1];
-var varnishPort = parseInt(hostPortMatch[2]);
+const varnishIP = process.argv[2];
+const purgeURL = process.argv[3];
+const hostPortMatch = varnishIP.match(/((?:\d{1,3}\.){3}\d{1,3}):(\d{4})/);
+const varnishHostIp = hostPortMatch[1];
+const varnishPort = parseInt(hostPortMatch[2]);
 
-var purger = new HTCPPurger({
+const purger = new HTCPPurger({
     log: console.log.bind(console),
     routes: [{
             host: varnishHostIp,
@@ -29,6 +29,6 @@ var purger = new HTCPPurger({
         }]
 });
 
-console.log('Sending a datagram to ' + varnishHostIp + ':' + varnishPort + ' for uri ' + purgeURL);
+console.log(`Sending a datagram to ${varnishHostIp}:${varnishPort} for uri ${purgeURL}`);
 purger.purge([purgeURL]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htcp-purge",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Varnish caches purging method",
   "main": "index.js",
   "scripts": {
@@ -19,6 +19,9 @@
   ],
   "author": "Wikimedia Service Team <services@wikimedia.org>",
   "license": "Apache-2.0",
+  "engines": {
+    "node": ">=4"
+  },
   "dependencies": {
     "core-js": "^2.0.3",
     "bluebird": "^3.1.1"
@@ -27,6 +30,8 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4",
     "mocha-jshint": "^2.2.6",
-    "mocha-lcov-reporter": "^1.0.0"
+    "mocha-lcov-reporter": "^1.0.0",
+    "mocha-eslint":"^3.0.1",
+    "eslint-config-node-services": "^1.0.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,23 +1,24 @@
 "use strict";
 
 require('mocha-jshint')();
+require('mocha-eslint')([ 'index.js' ]);
 
-var HTCPPurger = require('../index');
-var assert = require('assert');
-var dgram = require('dgram');
+const HTCPPurger = require('../index');
+const assert = require('assert');
+const dgram = require('dgram');
 
-describe('Protocol tests', function() {
-    var referenceBuffer = new Buffer([0, 44, 0, 0, 0, 38, 4, 0,
+describe('Protocol tests', () => {
+    const referenceBuffer = new Buffer([0, 44, 0, 0, 0, 38, 4, 0,
         0, 0, 0, 1, 0, 0, 0, 4, 72, 69, 65, 68, 0, 8,
         116, 101, 115, 116, 46, 99, 111, 109, 0, 8, 72,
         84, 84, 80, 47, 49, 46, 48, 0, 0, 0, 2]);
-    var referenceBuffer2 = new Buffer([0, 44, 0, 0, 0, 38, 4, 0,
+    const referenceBuffer2 = new Buffer([0, 44, 0, 0, 0, 38, 4, 0,
         0, 0, 0, 2, 0, 0, 0, 4, 72, 69, 65, 68, 0, 8,
         116, 101, 115, 116, 46, 99, 111, 109, 0, 8, 72,
         84, 84, 80, 47, 49, 46, 48, 0, 0, 0, 2]);
 
-    it('should construct correct datagram', function() {
-        var purger = new HTCPPurger({
+    it('should construct correct datagram', () => {
+        const purger = new HTCPPurger({
             routes: [
                 {
                     host: 'default',
@@ -25,12 +26,12 @@ describe('Protocol tests', function() {
                 }
             ]
         });
-        var resultDatagram = purger._constructHTCPRequest('test.com');
+        const resultDatagram = purger._constructHTCPRequest('test.com');
         assert.deepEqual(referenceBuffer, resultDatagram);
     });
 
-    it ('should lookup route by regex', function() {
-        var purger = new HTCPPurger({
+    it ('should lookup route by regex', () => {
+        const purger = new HTCPPurger({
             routes: [
                 {
                     rule: '/https?:\\/\\/test\\.com/',
@@ -43,17 +44,17 @@ describe('Protocol tests', function() {
                 }
             ]
         });
-        var route = purger._lookupRoute('http://test.com');
+        const route = purger._lookupRoute('http://test.com');
         assert.deepEqual('123.123.123.123', route.host);
         assert.deepEqual(1234, route.port);
-        var route2 = purger._lookupRoute('http://test2.com');
+        const route2 = purger._lookupRoute('http://test2.com');
         assert.deepEqual('default', route2.host);
         assert.deepEqual(1234, route2.port);
     });
 
     it ('should send datagrams' ,function(done) {
         this.timeout(5000);
-        var purger = new HTCPPurger({
+        const purger = new HTCPPurger({
             routes: [
                 {
                     host: 'localhost',
@@ -61,21 +62,24 @@ describe('Protocol tests', function() {
                 }
             ]
         });
-        var server = dgram.createSocket('udp4');
-        server.on("message", function (msg) {
+        const server = dgram.createSocket('udp4');
+        server.on("message", msg => {
             assert.deepEqual(referenceBuffer, msg);
             done();
         });
         server.bind(12345);
-        return purger.purge(['test.com'])
+        return purger
+        .bind()
+        .then(() => purger.purge(['test.com']))
         .delay(100)
-        .then(function() {
+        .finally(() => {
+            purger.close();
             server.close();
         });
     });
 
-    it ('should increase seq num of datagrams' ,function(done) {
-        var purger = new HTCPPurger({
+    it ('should increase seq num of datagrams' ,done => {
+        const purger = new HTCPPurger({
             routes: [
                 {
                     host: 'localhost',
@@ -83,9 +87,9 @@ describe('Protocol tests', function() {
                 }
             ]
         });
-        var server = dgram.createSocket('udp4');
-        var msgIdx = 1;
-        server.on("message", function (msg) {
+        const server = dgram.createSocket('udp4');
+        let msgIdx = 1;
+        server.on("message", msg => {
             if (msgIdx === 1) {
                 assert.deepEqual(referenceBuffer, msg);
                 msgIdx++;
@@ -96,12 +100,14 @@ describe('Protocol tests', function() {
         });
         server.bind(12346);
 
-        return purger.purge(['test.com'])
+        return purger.bind()
+        .then(() => purger.purge(['test.com']))
         .delay(100)
-        .then(function() {
-            return purger.purge(['test.com']);
+        .then(() => purger.purge(['test.com']))
+        .delay(100)
+        .then(() => {
+            purger.close();
+            server.close();
         })
-        .delay(100)
-        .then(function() { server.close(); })
     });
 });


### PR DESCRIPTION
Important changes:
- New API - we create a single 'socket' now and reuse it between purge invocations.
- Providing the `exclusive` option to avoid sharing handles - it's a workaround for https://phabricator.wikimedia.org/T147849 until a real solution is found.
- ES6, ESLint

cc @wikimedia/services 
