### PR TITLE
Don't throw if failed to gracefully shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,11 @@ class HTCPPurger {
     }
 
     close() {
-        return this.socket.close();
+        try {
+            return this.socket.close();
+        } catch (e) {
+            // We've tried, but seems like socket is already closed, so swallow the error.
+        }
     }
     /**
      * Construct a UDP datagram with HTCP packet for Varnish flush of the url

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htcp-purge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Varnish caches purging method",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The socket might already be closed by the time we've got to graceful shutdown method - don't fail brutally in that case.

cc @wikimedia/services 