### PR TITLE
Update dependencies ad remove core-js dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 "use strict";
 
-require('core-js/shim');
-
 const P = require('bluebird');
 const dgram = P.promisifyAll(require('dgram'));
 
@@ -29,7 +27,7 @@ class HTCPPurger {
         this.options.routes.forEach((routeSpec) => {
             if (routeSpec.rule && /^\/.+\/$/.test(routeSpec.rule)) {
                 const regExp = new RegExp(routeSpec.rule.substring(1, routeSpec.rule.length - 1));
-                routeSpec.rule = (url) => regExp.test(url);
+                routeSpec.rule = url => regExp.test(url);
             } else {
                 routeSpec.rule = () => true;
             }
@@ -51,8 +49,8 @@ class HTCPPurger {
 
     /**
      * Purge a list of resources cahced under provided URLs
-     *
-     * @param urls array of urls to purge
+     * @param {Array} urls array of urls to purge
+     * @return {Promise}
      */
     purge(urls) {
         return P.all(urls.map((url) => {
@@ -75,8 +73,8 @@ class HTCPPurger {
     }
     /**
      * Construct a UDP datagram with HTCP packet for Varnish flush of the url
-     * @param url a url of the resource that should be flushed
-     * @returns {Buffer} resulting HTCP packet bytes
+     * @param {string} url a url of the resource that should be flushed
+     * @return {Buffer} resulting HTCP packet bytes
      * @private
      */
     _constructHTCPRequest(url) {
@@ -121,12 +119,12 @@ class HTCPPurger {
     /**
      * Lookup a cache endpoint for a concrete URL, based on options
      * supplied in constructor
-     * @param url URL to lookup cache endpoint for
-     * @returns {Object} an opbject with host and port keys
+     * @param {string} url URL to lookup cache endpoint for
+     * @return {Object} an opbject with host and port keys
      * @private
      */
     _lookupRoute(url) {
-        const route = this.options.routes.find((route) => route.rule(url));
+        const route = this.options.routes.find(route => route.rule(url));
         if (!route) {
             this.log('error/htcp-purge', {
                 msg: `Could not find route for ${url}`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htcp-purge",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Varnish caches purging method",
   "main": "index.js",
   "scripts": {
@@ -20,18 +20,20 @@
   "author": "Wikimedia Service Team <services@wikimedia.org>",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "dependencies": {
-    "core-js": "^2.0.3",
-    "bluebird": "^3.1.1"
+    "bluebird": "^3.5.1"
   },
   "devDependencies": {
-    "istanbul": "^0.4.2",
-    "mocha": "^2.3.4",
-    "mocha-jshint": "^2.2.6",
-    "mocha-lcov-reporter": "^1.0.0",
-    "mocha-eslint":"^3.0.1",
-    "eslint-config-node-services": "^1.0.0"
+    "istanbul": "^0.4.5",
+    "mocha": "^5.1.0",
+    "mocha-jshint": "^2.3.1",
+    "mocha-lcov-reporter": "^1.3.0",
+    "mocha-eslint": "^4.1.0",
+    "eslint-config-node-services": "^2.2.5",
+    "eslint-config-wikimedia": "^0.5.0",
+    "eslint-plugin-jsdoc": "^3.6.3",
+    "eslint-plugin-json": "^1.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -68,7 +68,7 @@ describe('Protocol tests', () => {
             done();
         });
         server.bind(12345);
-        return purger
+        purger
         .bind()
         .then(() => purger.purge(['test.com']))
         .delay(100)
@@ -100,7 +100,7 @@ describe('Protocol tests', () => {
         });
         server.bind(12346);
 
-        return purger.bind()
+        purger.bind()
         .then(() => purger.purge(['test.com']))
         .delay(100)
         .then(() => purger.purge(['test.com']))


### PR DESCRIPTION
This module is the only one bringing the whole huge core-js into change-propagation service. Since we run on node 6 we don't use any shims anymore, so get rid of the core-js dependency. 

Plus, update dependencies, fix code style, explicitly depend on peer dependencies for eslint.

cc @wikimedia/services 